### PR TITLE
Develop

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -20,7 +20,10 @@ jobs:
           node-version: '20.x'
           registry-url: 'https://npm.pkg.github.com'
           scope: '@slaega'
-
+      
+      - run: |
+          corepack enable
+          corepack prepare yarn@4.9.1 --activate
       - run: yarn
       - run: yarn build
 

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -19,6 +19,9 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           always-auth: true
           
+      - run: |
+          corepack enable
+          corepack prepare yarn@4.9.1 --activate    
       - run: yarn 
       - run: yarn build
       - run: yarn publish --access public --tag latest


### PR DESCRIPTION
📦 Migration vers Yarn 4 via Corepack
Cette pull request corrige les erreurs liées à l'utilisation de Yarn v1 dans le workflow CI, alors que le projet utilise Yarn 4 via Corepack.

Changements :
Activation explicite de Corepack dans le pipeline CI

Installation de la version spécifiée (yarn@4.9.1) comme défini dans le champ packageManager du package.json

Résout :
Closes #15 
Closes #10 
Closes #8 
Closes #9 
Closes #12 